### PR TITLE
Add Namespaces to Resources

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 0.7.4
+version: 0.7.5
 appVersion: v0.7.1
 icon: https://github.com/provectus/kafka-ui/raw/master/documentation/images/kafka-ui-logo.png

--- a/charts/kafka-ui/templates/configmap.yaml
+++ b/charts/kafka-ui/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 data:

--- a/charts/kafka-ui/templates/configmap_fromValues.yaml
+++ b/charts/kafka-ui/templates/configmap_fromValues.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kafka-ui.fullname" . }}-fromvalues
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 data:

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/kafka-ui/templates/hpa.yaml
+++ b/charts/kafka-ui/templates/hpa.yaml
@@ -9,6 +9,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 spec:

--- a/charts/kafka-ui/templates/ingress.yaml
+++ b/charts/kafka-ui/templates/ingress.yaml
@@ -13,6 +13,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/kafka-ui/templates/networkpolicy-egress.yaml
+++ b/charts/kafka-ui/templates/networkpolicy-egress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-egress" (include "kafka-ui.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 spec:

--- a/charts/kafka-ui/templates/networkpolicy-ingress.yaml
+++ b/charts/kafka-ui/templates/networkpolicy-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-ingress" (include "kafka-ui.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 spec:

--- a/charts/kafka-ui/templates/secret.yaml
+++ b/charts/kafka-ui/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/kafka-ui/templates/service.yaml
+++ b/charts/kafka-ui/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 {{- if .Values.service.annotations }}

--- a/charts/kafka-ui/templates/serviceaccount.yaml
+++ b/charts/kafka-ui/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kafka-ui.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
### Problem

We currently use Kustomize to render multiple instances of Kafka UI in a single overlay, but doing so results in multiple copies of the same entities being rendered because they aren't correctly namespaced:

Example `kustomization.yaml`:
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

helmCharts:
- releaseName: kafka-ui-1
  namespace: deployment-1
  name: kafka-ui
  repo: https://provectus.github.io/kafka-ui-charts
  version: 0.7.4
- releaseName: kafka-ui-2
  name: kafka-ui
  namespace: deployment-2
  repo: https://provectus.github.io/kafka-ui-charts
  version: 0.7.4
```

The above should result in 2 copies of each resource, one set for `deployment-1` namespace and one for `deployment-2` namespace. With the current chart you end up with only one of each resource type _except_ for the `Deployment` which is correctly namespaced in the template.