### PR TITLE
Fix up missing notes when using an ingress

### DIFF
--- a/charts/kafka-ui/templates/NOTES.txt
+++ b/charts/kafka-ui/templates/NOTES.txt
@@ -1,10 +1,6 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
-  {{- end }}
-{{- end }}
+  Visit http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}{{ .Values.ingress.path }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kafka-ui.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -111,6 +111,7 @@ ingress:
   ingressClassName: ""
 
   # The path for the Ingress
+  # Ensure to set envs.config.SERVER_SERVLET_CONTEXT_PATH if you want it to work at a subpath other than /
   path: "/"
 
   # The path type for the Ingress


### PR DESCRIPTION
When deploying this chart I noticed that I got a broken/incomplete output message.

```
Release "kafka-ui" has been upgraded. Happy Helming!
NAME: kafka-ui
LAST DEPLOYED: ...
NAMESPACE: ....
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
```

It looks like at the time this was developed it was uncertain if hosts should be a list or single path. 
How does the following fix strike you?

I've also added a comment about setting the config value `SERVER_SERVLET_CONTEXT_PATH` for when the server is running at a subpath as this tripped me up when testing this.