### PR TITLE
Add custom labels for the Ingress

### DIFF
--- a/charts/kafka-ui/templates/ingress.yaml
+++ b/charts/kafka-ui/templates/ingress.yaml
@@ -16,6 +16,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}  
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -103,7 +103,8 @@ service:
 ingress:
   # Enable ingress resource
   enabled: false
-
+  # Custom labels for the Ingress
+  labels: {}
   # Annotations for the Ingress
   annotations: {}
 


### PR DESCRIPTION
Hello!

This PR allows the addition of custom labels to the Kafka-UI ingress.
For example, I need to add some special labels for selecting Kafka-UI ingress in our projects and some automation. For now, we do not use the native ingress from this chart. Instead, we have to create custom ingress and it is not convenient.
Perhaps it will be useful for somebody else.

Best regards,
Maksim