### PR TITLE
Make liveness and readiness probes configurable (#29)

### DIFF
--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -91,9 +91,11 @@ spec:
               {{- if .Values.probes.useHttpsScheme }}
               scheme: HTTPS
               {{- end }}
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}            
           readinessProbe:
             httpGet:
               {{- $contextPath := .Values.envs.config.SERVER_SERVLET_CONTEXT_PATH | default "" | printf "%s/actuator/health" | urlParse }}
@@ -102,9 +104,11 @@ spec:
               {{- if .Values.probes.useHttpsScheme }}
               scheme: HTTPS
               {{- end }}
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}            
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.yamlApplicationConfig .Values.volumeMounts .Values.yamlApplicationConfigConfigMap}}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -77,6 +77,18 @@ annotations: {}
 ##
 probes:
   useHttpsScheme: false
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
+  readinessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
 
 podSecurityContext:
   {}


### PR DESCRIPTION
Resolves https://github.com/provectus/kafka-ui-charts/issues/29

Helm template diff of the generated chart (`helm template "kafka-ui" charts/kafka-ui`):

```
diff --git a/old b/new
index cf6bb91..ab19b95 100644
--- a/old
+++ b/new
@@ -84,6 +84,8 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3            
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -91,5 +93,7 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3            
           resources:
             {}
```

The newly added `successThreshold` and `failureThreshold` correspond to the [kubernetes probe defaults](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#probe-v1-core).