### PR TITLE
Use stringData instead of data in secret

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 0.7.5
+version: 0.7.6
 appVersion: v0.7.1
 icon: https://github.com/provectus/kafka-ui/raw/master/documentation/images/kafka-ui-logo.png

--- a/charts/kafka-ui/templates/secret.yaml
+++ b/charts/kafka-ui/templates/secret.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 type: Opaque
-data:
+stringData:
   {{- range $key, $val := .Values.envs.secret }}
-  {{ $key }}: {{ $val | b64enc | quote }}
+  {{ $key }}: {{ $val | quote }}
   {{- end -}}
 {{- end}}


### PR DESCRIPTION
Currently, the secret values need to be encoded with base64. This is not necessary as you won't have any binary data in this context (see [here](https://livebook.manning.com/concept/kubernetes/stringdata-field)).

Additionally, it prevents usage of the chart with [helm-secrets](https://github.com/jkroepke/helm-secrets) in combination with [vals](https://github.com/helmfile/vals) as secrets are first base64-encoded and the vals expressions are evaluated after that.