### PR TITLE
Helm chart: Add service labels and document service annotations

### DIFF
--- a/charts/kafka-ui/templates/service.yaml
+++ b/charts/kafka-ui/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | nindent 4 }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -92,6 +92,12 @@ securityContext:
   # runAsUser: 1000
 
 service:
+  # Annotations for the Service
+  annotations: {}
+
+  # Labels for the Service
+  labels: {}
+
   type: ClusterIP
   port: 80
   # In case of service type LoadBalancer, you can specify reserved static IP


### PR DESCRIPTION
Hello!
This MR is based on the also created issue: https://github.com/provectus/kafka-ui-charts/issues/35 Helm chart: Add service labels and document service annotations

It adds the possibility to define labels for the service via the helm values.
Additionally, it documents the possibility to define annotations on the service.  


Related issues:
https://github.com/provectus/kafka-ui-charts/pull/25 Add custom labels for the Ingress
https://github.com/provectus/kafka-ui-charts/pull/28 Add custom labels to deployment

Best Regards
Lorenz