### PR TITLE
chore(release-helm): add OCI registry support to Helm release workflow"

### DIFF
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -37,3 +37,14 @@ jobs:
       - uses: rickstaa/action-create-tag@v1 #create new tag
         with:
           tag: "charts/kafka-ui-${{ env.HELM_VERSION }}"
+
+      - name: Login to OCI registry
+        run: |
+          echo "${{ secrets.OCI_REGISTRY_PASSWORD }}" | helm registry login -u ${{ secrets.OCI_REGISTRY_USERNAME }} --password-stdin ${{ secrets.OCI_REGISTRY_URL }}
+
+      - name: Package and push Helm chart to OCI registry
+        run: |
+          VERSION=$(cat charts/kafka-ui/Chart.yaml | grep version | awk '{print $2}')
+          echo "HELM_VERSION=$(echo ${VERSION})" >> $GITHUB_ENV
+          helm package charts/kafka-ui
+          helm push charts/kafka-ui-${{ env.HELM_VERSION }}.tgz oci://${{ secrets.OCI_REGISTRY_URL }}/helm-charts


### PR DESCRIPTION
This pull request introduces support for OCI (Open Container Initiative) registry for Helm chart deployment. The changes include:

- Login to OCI registry:

Added a step to log in to the OCI registry using GitHub secrets (OCI_REGISTRY_USERNAME, OCI_REGISTRY_PASSWORD, OCI_REGISTRY_URL).

- Package and push Helm chart to OCI registry:

Updated the workflow to package the Helm chart and push it to the OCI registry using the helm push command.

**Related Issues:**

Fixes #39